### PR TITLE
activate syntax on any file that begins with 'jenkinsfile'

### DIFF
--- a/jenkinsfile-syntax.py
+++ b/jenkinsfile-syntax.py
@@ -6,6 +6,5 @@ class JenkinsfileSyntax(sublime_plugin.EventListener):
     def on_load(self, view):
         filename = view.file_name().split('/')
 
-        if len(filename) and 'jenkinsfile' in filename[-1].lower():
+        if len(filename) and filename[-1].lower().startswith('jenkinsfile'):
             view.set_syntax_file('Packages/jenkinsfile-syntax/Groovy.tmLanguage')
-


### PR DESCRIPTION
We often name our Jenkinsfile files with various suffixes and decorations. However the files always begin with "Jenkinsfile" (sometimes, but not often, lowercase 'jenkinsfile').

This small modification activates this wonderful language syntax on such-named files.